### PR TITLE
huge internal simplification with iters and real errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug)]
 pub enum Error {
     IOError(std::io::Error),
-    NomError(String),
+    ParseError(String),
 }
 
 impl std::fmt::Display for Error {
@@ -39,7 +39,7 @@ impl From<std::io::Error> for Error {
 
 impl<E: std::fmt::Debug> From<nom::Err<E>> for Error {
     fn from(error: nom::Err<E>) -> Self {
-        Error::NomError(format!("{}", error))
+        Error::ParseError(format!("{}", error))
     }
 }
 


### PR DESCRIPTION
1. returns its own error type, which is either a parsing error or an io error
2. greatly simplifies parsing by using an iterator instead of manual buffer management
3. cleans up a ton of error handling, especially in mesh_ascii by using `?`
4. benchmarks at least as fast as master

This is a breaking change to the interface, but I think it's worthwhile as it reduces what clients have to care about, and the migration path is easy.

Old signature:
```rust
pub fn parse_stl<R: Read + Seek, N: XYZ, V: XYZ>(bytes: &mut R) -> Result<(Vec<u8>, Mesh<N, V>)>
```

New signature:
```rust
pub fn parse_stl<R: Read + Seek, N: XYZ, V: XYZ>(bytes: &mut R) -> Result<Mesh<N, V>>
```

with the two main changes being:
1. The returned `Result` no longer is a tuple containing unread bytes as its first arg. We never used this anywhere so it was always thrown away.
2. `Result` is now either a `Mesh` (same as before) or an error enum, so callers will be able to report more information in logs etc. as to why it actually failed:
```rust
pub enum Error {
    IOError(std::io::Error),
    ParseError(String),
}
```