### PR TITLE
f32 optimization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use nom::character::complete::{line_ending, multispace0, multispace1};
 use nom::combinator::{opt, rest};
 use nom::multi::many1;
 use nom::number::complete::{float, le_f32};
-use nom::{eat_separator, named, IResult};
+use nom::IResult;
 use std::{
     collections::{HashMap, HashSet},
     convert::TryInto,
@@ -438,8 +438,6 @@ fn mesh_ascii(s: &[u8]) -> Result<Mesh> {
 fn to_crate_err(e: nom::Err<(&[u8], nom::error::ErrorKind)>) -> Error {
     e.into()
 }
-
-named!(whitespace, eat_separator!(&b" \t\r\n"[..]));
 
 fn three_floats(s: &[u8]) -> IResult<&[u8], Vertex> {
     let (s, f1) = float(s)?;


### PR DESCRIPTION
This PR does two things:

- improves binary parsing speed from 984 MB/s to 1,656 MB/s, according to the following benchmarks. Not that it was really a problem, but this is basically free performance.
- removes a custom whitespace parser definition that wasn't called anywhere

Master:

```
nom_stl on  master is 📦 v0.1.0 via Rust v1.47.0 on 🅰 (us-gov-west-1) took 35s
at [ 15:49:46 ] ➜ cargo bench
    Finished bench [optimized] target(s) in 0.06s
     Running target/release/deps/nom_stl-eb6fd43d17d2fb83

running 14 tests
test properties::prop_parses_binary_stl_with_at_least_one_triangle ... ignored
test tests::all_vertices ... ignored
test tests::creates_an_index_mesh ... ignored
test tests::does_ascii_file_without_a_closing_solid_name ... ignored
test tests::does_ascii_from_file ... ignored
test tests::does_binary_from_file ... ignored
test tests::does_binary_from_file_starting_with_solid ... ignored
test tests::makes_unique_vertices ... ignored
test tests::parses_ascii_mesh ... ignored
test tests::parses_ascii_triangles ... ignored
test tests::parses_both_ascii_and_binary ... ignored
test tests::parses_mesh ... ignored
test tests::parses_stl_with_dos_line_endings_crlf ... ignored
test tests::parses_triangles ... ignored

test result: ok. 0 passed; 0 failed; 14 ignored; 0 measured; 0 filtered out

     Running target/release/deps/bench-019b70f0d5d45e78
big/parse_stl_root_vase_binary_big_unindexed
                        time:   [28.913 ms 29.450 ms 29.940 ms]
                        change: [-0.9199% +1.2260% +3.3522%] (p = 0.31 > 0.05)
                        No change in performance detected.

parse_stl_moon_prism_power_binary
                        time:   [158.04 us 161.64 us 165.17 us]
                        change: [+6.3526% +8.5420% +10.429%] (p = 0.00 < 0.05)
                        Performance has regressed.

parse_stl_moon_prism_power_ascii
                        time:   [822.77 us 829.03 us 834.74 us]
                        change: [+3.4986% +4.3528% +5.1700%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

This branch:

```
nom_stl on  f32-optimization is 📦 v0.1.0 via Rust v1.47.0 on 🅰 (us-gov-west-1) took 17ms
at [ 15:51:09 ] ➜ cargo bench
   Compiling nom_stl v0.1.0 (/Users/clark/code/nom_stl)
    Finished bench [optimized] target(s) in 49.60s
     Running target/release/deps/nom_stl-eb6fd43d17d2fb83

running 14 tests
test properties::prop_parses_binary_stl_with_at_least_one_triangle ... ignored
test tests::all_vertices ... ignored
test tests::creates_an_index_mesh ... ignored
test tests::does_ascii_file_without_a_closing_solid_name ... ignored
test tests::does_ascii_from_file ... ignored
test tests::does_binary_from_file ... ignored
test tests::does_binary_from_file_starting_with_solid ... ignored
test tests::makes_unique_vertices ... ignored
test tests::parses_ascii_mesh ... ignored
test tests::parses_ascii_triangles ... ignored
test tests::parses_both_ascii_and_binary ... ignored
test tests::parses_mesh ... ignored
test tests::parses_stl_with_dos_line_endings_crlf ... ignored
test tests::parses_triangles ... ignored

test result: ok. 0 passed; 0 failed; 14 ignored; 0 measured; 0 filtered out

     Running target/release/deps/bench-019b70f0d5d45e78
big/parse_stl_root_vase_binary_big_unindexed
                        time:   [17.178 ms 17.504 ms 17.737 ms]
                        change: [-41.909% -40.509% -39.009%] (p = 0.00 < 0.05)
                        Performance has improved.

parse_stl_moon_prism_power_binary
                        time:   [78.145 us 78.299 us 78.499 us]
                        change: [-52.487% -51.682% -50.859%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  6 (6.00%) high severe

parse_stl_moon_prism_power_ascii
                        time:   [536.51 us 538.73 us 540.78 us]
                        change: [-35.397% -34.886% -34.397%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  10 (10.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
```

