### PR TITLE
use a byte slice interface, abandon R: Read + Seek

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,18 +4,20 @@ extern crate criterion;
 use criterion::Criterion;
 use nom_stl::parse_stl;
 use std::fs::File;
-use std::io::BufReader;
+use std::io::{BufReader, Read};
 
 fn parse_stl_binary_big(c: &mut Criterion) {
     let root_vase_file = File::open("./fixtures/Root_Vase.stl").unwrap();
     let mut root_vase = BufReader::new(&root_vase_file);
+    let mut root_vase_buf = vec![];
+    root_vase.read_to_end(&mut root_vase_buf).unwrap();
 
     let mut group = c.benchmark_group("big");
 
     group.sample_size(15);
 
     group.bench_function("parse_stl_root_vase_binary_big_unindexed", move |b| {
-        b.iter(|| parse_stl::<BufReader<&File>>(&mut root_vase))
+        b.iter(|| parse_stl(&mut root_vase_buf).unwrap())
     });
 
     group.finish();
@@ -24,18 +26,22 @@ fn parse_stl_binary_big(c: &mut Criterion) {
 fn parse_stl_binary(c: &mut Criterion) {
     let moon_file = std::fs::File::open("./fixtures/MOON_PRISM_POWER_binary.stl").unwrap();
     let mut moon = BufReader::new(&moon_file);
+    let mut moon_buf = vec![];
+    moon.read_to_end(&mut moon_buf).unwrap();
 
     c.bench_function("parse_stl_moon_prism_power_binary", move |b| {
-        b.iter(|| parse_stl::<BufReader<&File>>(&mut moon))
+        b.iter(|| parse_stl(&mut moon_buf).unwrap())
     });
 }
 
 fn parse_stl_ascii(c: &mut Criterion) {
     let moon_file = std::fs::File::open("./fixtures/MOON_PRISM_POWER.stl").unwrap();
     let mut moon = BufReader::new(&moon_file);
+    let mut moon_buf = vec![];
+    moon.read_to_end(&mut moon_buf).unwrap();
 
     c.bench_function("parse_stl_moon_prism_power_ascii", move |b| {
-        b.iter(|| parse_stl::<BufReader<&File>>(&mut moon))
+        b.iter(|| parse_stl(&mut moon_buf).unwrap())
     });
 }
 


### PR DESCRIPTION
I don't know if this is a good idea, mostly throwing it up here to explore.

This pr:
- makes an interface breaking change to take `&[u8]` instead of `R: Read + Seek`
- abandons the internal iterator that was in charge of parsing binary triangles, and replaces it with a single preallocated vector
- updates the tests and benchmarks to the `&[u8]` signature

This also represents a change of responsibilities, as it makes the caller responsible for producing the input bytes, rather than reading them internally via the `R: Read + Seek` interface. Is this better? Worse? I'm not sure.


The benchmarks now look like this:

```
                                                                                                                       big/parse_stl_root_vase_binary_big_unindexed
                        time:   [6.9598 ms 6.9762 ms 6.9963 ms]
Found 3 outliers among 15 measurements (20.00%)
  1 (6.67%) low mild
  1 (6.67%) high mild
  1 (6.67%) high severe

                                                                                                              parse_stl_moon_prism_power_binary
                        time:   [31.788 us 31.889 us 32.024 us]
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe

Benchmarking parse_stl_moon_prism_power_ascii: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.3s, enable flat sampling, or reduce sample count to 50.
                                                                                                             parse_stl_moon_prism_power_ascii
                        time:   [1.8389 ms 1.8511 ms 1.8651 ms]
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  10 (10.00%) high severe
```

vs previous that looked like:

```
                                                                                                                       big/parse_stl_root_vase_binary_big_unindexed
                        time:   [18.204 ms 18.884 ms 19.460 ms]

                                                                                                             parse_stl_moon_prism_power_binary
                        time:   [86.096 us 87.391 us 89.134 us]
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

                                                                                                            parse_stl_moon_prism_power_ascii
                        time:   [576.49 us 582.57 us 589.23 us]
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe
```
