### PR TITLE
bugfix: allow ascii files with no stl file name and no space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Changelog
 
+## 0.2.1 - 2021-02-02
+
+- Allow the parsing of ASCII STL files that do not contain a filename or a space after the initial opening `solid` string.
+
 ## 0.2.0 - 2020-11-05
 
 ### Notable changes
 
-README updates, rustdoc link
+- README updates, rustdoc link
 
 ## 0.1.0 - 2020-11-05
 
 ### Notable changes
 
-Open sourced!
+- Open sourced!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nom_stl"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Clark Kampfe <clark.kampfe@fastradius.com>", "Aaron Brenzel <aaron.brenzel@fastradius.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,7 +422,7 @@ fn not_line_ending(c: u8) -> bool {
 }
 
 fn mesh_ascii(s: &[u8]) -> Result<Mesh> {
-    let (s, _) = tag("solid ")(s).map_err(to_crate_err)?;
+    let (s, _) = tag("solid")(s).map_err(to_crate_err)?;
     let (s, _) = opt(take_while1(not_line_ending))(s).map_err(to_crate_err)?;
     let (s, _) = line_ending(s).map_err(to_crate_err)?;
     let (s, triangles) = many1(triangle_ascii)(s)?;
@@ -794,6 +794,40 @@ mod tests {
     #[test]
     fn creates_an_index_mesh() {
         let mesh_string = "solid OpenSCAD_Model
+               facet normal 0.642777 -2.54044e-006 0.766053
+                 outer loop
+                   vertex 8.08661 0.373289 54.1924
+                   vertex 8.02181 0.689748 54.2468
+                   vertex 8.10936 0 54.1733
+                 endloop
+               endfacet
+               facet normal -0.281083 -0.678599 -0.678599
+                 outer loop
+                   vertex 8.08661 0.373289 54.1924
+                   vertex 8.02181 0.689748 54.2468
+                   vertex 0 7.342 8.6529
+                 endloop
+               endfacet
+               facet normal -0.281083 -0.678599 -0.678599
+                 outer loop
+                   vertex 8.08661 0.373289 54.1924
+                   vertex 8.02181 0.689748 54.2468
+                   vertex 4.0 4.0 4.0
+                 endloop
+               endfacet
+             endsolid OpenSCAD_Model";
+
+        let mesh = parse_stl(&mut std::io::Cursor::new(mesh_string.as_bytes().to_owned())).unwrap();
+
+        let index_mesh: IndexMesh = mesh.into();
+
+        assert_eq!(index_mesh.triangles().len(), 3);
+        assert_eq!(index_mesh.vertices().len(), 5);
+    }
+
+    #[test]
+    fn ascii_without_an_opening_file_name() {
+        let mesh_string = "solid
                facet normal 0.642777 -2.54044e-006 0.766053
                  outer loop
                    vertex 8.08661 0.373289 54.1924


### PR DESCRIPTION
Fixes a parse error when given an stl that lacks both a space and a filename after the opening `solid` string. This is more tolerant than is typical, as the space is usually required, even in the case when the model name is missing.